### PR TITLE
MANIFEST.SKIP: ignore MYMETA.*, .gitignore

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -10,6 +10,7 @@
 ^MakeMaker-\d
 \.gz$
 \.cvsignore
+\.gitignore$
 ^t/9\d_.*\.t
 ^t/perlcritic
 ^tools/
@@ -22,3 +23,4 @@
 nytprof/
 \.rej$
 \.orig$
+^MYMETA.


### PR DESCRIPTION
MYMETA.\* are files generated at install time. They must not be bundled in the archive.
