### PR TITLE
Carp lazy loading: use goto

### DIFF
--- a/lib/Class/Accessor/Lite.pm
+++ b/lib/Class/Accessor/Lite.pm
@@ -4,7 +4,7 @@ use strict;
 
 our $VERSION = '0.07';
 
-sub croak {require Carp; Carp::croak(@_)}
+sub croak {require Carp; goto &Carp::croak}
 
 sub import {
     shift;


### PR DESCRIPTION
Improves #6.
Use goto in Carp::croak wrapper to not affect the call stack. And it's faster.
