### PR TITLE
perl-5.26.0 compatibility.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,5 @@
 use strict;
+use lib '.';
 use inc::Module::Install;
 
 name('Class-Accessor-Lite');


### PR DESCRIPTION
In Perl 5.26.0, '.' will no longer be found by default in @INC.  This patch
adjusts Makefile.PL to accommodate that change.

For:  https://rt.cpan.org/Ticket/Display.html?id=120737